### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/MvcHybridClient/MvcHybridClient.csproj
+++ b/MvcHybridClient/MvcHybridClient.csproj
@@ -5,16 +5,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="5.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi@damienbod, I found an issue in the MvcHybridClient.csproj:

Packages Microsoft.AspNetCore.Authentication.OpenIdConnect v5.0.1, Microsoft.AspNetCore.Mvc.NewtonsoftJson v5.0.1, Serilog.Sinks.Seq v4.0.0, Serilog.Sinks.Console v 3.1.1 and Serilog.Sinks.File v4.1.0 transitively introduce 104 dependencies into AspNetCoreWindowsAuth’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/AspNetCoreWindowsAuth.html)), while  Microsoft.AspNetCore.Authentication.OpenIdConnect v5.0.8, Microsoft.AspNetCore.Mvc.NewtonsoftJson v5.0.8, Serilog.Sinks.Seq v5.0.0, Serilog.Sinks.Console v 4.0.0 and Serilog.Sinks.File v5.0.0 can only introduce 76 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/AspNetCoreWindowsAuth_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose